### PR TITLE
Add clang-format and workflow for code format checking

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,15 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+TabWidth: 4
+AccessModifierOffset: -4
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+BreakBeforeBraces: Allman
+ColumnLimit: 0
+IndentCaseLabels: true
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+ContinuationIndentWidth: 8
+SpacesInSquareBrackets: false

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,23 @@
+name: Format Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install clang-format
+      run: sudo apt-get install -y clang-format
+
+    - name: Check formatting
+      run: |
+        find . -type f \( -name "*.cc" -o -name "*.hh" \) -exec clang-format -n -Werror {} +
+

--- a/engine/include/spear/camera.hh
+++ b/engine/include/spear/camera.hh
@@ -1,8 +1,8 @@
 #ifndef SPEAR_CAMERA_HH
 #define SPEAR_CAMERA_HH
 
-#include <glm/vec3.hpp>
 #include <glm/mat4x2.hpp>
+#include <glm/vec3.hpp>
 
 namespace spear
 {
@@ -13,14 +13,13 @@ public:
     const float ASPECT_RATIO = 16.f / 9.f;
 
     /// Constructor.
-    Camera( glm::vec3 position = glm::vec3(0.f, 0.f, 0.f),
-            glm::vec3 up = glm::vec3(0.f, 1.f, 0.f),
-            float yaw = -90.f,
-            float pitch = 0.f,
-            float movement_speed = 2.5f,
-            float mouse_sentitivity = 0.1f,
-            float fov = 45.0f
-    );
+    Camera(glm::vec3 position = glm::vec3(0.f, 0.f, 0.f),
+           glm::vec3 up = glm::vec3(0.f, 1.f, 0.f),
+           float yaw = -90.f,
+           float pitch = 0.f,
+           float movement_speed = 2.5f,
+           float mouse_sentitivity = 0.1f,
+           float fov = 45.0f);
 
     /// \defgroup CameraGetters.
 
@@ -110,6 +109,6 @@ private:
     float m_fov;
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/entity.hh
+++ b/engine/include/spear/entity.hh
@@ -9,9 +9,8 @@ namespace spear
 class Entity : public Transform
 {
 public:
-
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/event_handler.hh
+++ b/engine/include/spear/event_handler.hh
@@ -14,7 +14,8 @@ public:
     using EventCallback = std::function<void(const SDL_Event&)>;
 
     /// Register a callback for a specific event type
-    void registerCallback(uint32_t eventType, EventCallback callback) {
+    void registerCallback(uint32_t eventType, EventCallback callback)
+    {
         callbacks[eventType] = callback;
     }
 
@@ -22,16 +23,22 @@ public:
     void handleEvents();
 
     /// Check if the application is still running
-    bool isRunning() const { return running; }
+    bool isRunning() const
+    {
+        return running;
+    }
 
     /// Set running to false, which can be called in an SDL_QUIT callback
-    void quit() { running = false; }
+    void quit()
+    {
+        running = false;
+    }
 
 private:
     std::unordered_map<uint32_t, EventCallback> callbacks;
     bool running = true;
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/material.hh
+++ b/engine/include/spear/material.hh
@@ -16,7 +16,7 @@ class Material
 {
 public:
     /// Constructor.
-    //Material(std::shared_ptr<rendering::BaseShader> shader, std::shared_ptr<rendering::BaseTexture> texture);
+    // Material(std::shared_ptr<rendering::BaseShader> shader, std::shared_ptr<rendering::BaseTexture> texture);
 
     /*
     static std::shared_ptr<Material> create(std::shared_ptr<rendering::BaseShader> shader, std::shared_ptr<rendering::BaseTexture> texture)
@@ -26,18 +26,27 @@ public:
     int32_t getShaderId() { return m_shader.getId(); }
     */
 
-
-    const int32_t& getColor() const { return m_color; }
-    const int32_t& getMvp() const { return m_mvp; }
-    const int32_t& getSampler() const { return m_sampler; }
+    const int32_t& getColor() const
+    {
+        return m_color;
+    }
+    const int32_t& getMvp() const
+    {
+        return m_mvp;
+    }
+    const int32_t& getSampler() const
+    {
+        return m_sampler;
+    }
 
     void use();
+
 private:
     int32_t m_mvp;
     int32_t m_color;
     int32_t m_sampler;
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/mesh.hh
+++ b/engine/include/spear/mesh.hh
@@ -1,8 +1,8 @@
 #ifndef SPEAR_MESH_HH
 #define SPEAR_MESH_HH
 
-#include <spear/material.hh>
 #include <spear/camera.hh>
+#include <spear/material.hh>
 
 #include <spear/rendering/base_shader.hh>
 #include <spear/rendering/base_texture.hh>
@@ -16,10 +16,11 @@ public:
     explicit Mesh(std::shared_ptr<rendering::BaseShader> shader);
 
     virtual void render(Camera& camera) = 0;
+
 protected:
     std::shared_ptr<rendering::BaseShader> m_shader;
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/rendering/api.hh
+++ b/engine/include/spear/rendering/api.hh
@@ -14,6 +14,6 @@ enum API
 
 bool isActive(API api);
 
-}
+} // namespace spear::rendering
 
 #endif

--- a/engine/include/spear/rendering/base_shader.hh
+++ b/engine/include/spear/rendering/base_shader.hh
@@ -1,9 +1,9 @@
 #ifndef SPEAR_SHADER_HH
 #define SPEAR_SHADER_HH
 
-#include <string>
 #include <cstdint>
 #include <memory>
+#include <string>
 
 #include <glm/mat4x4.hpp>
 
@@ -70,6 +70,6 @@ private:
     uint32_t m_id = 0;
 };
 
-}
+} // namespace spear::rendering
 
 #endif

--- a/engine/include/spear/rendering/base_texture.hh
+++ b/engine/include/spear/rendering/base_texture.hh
@@ -24,17 +24,25 @@ public:
     /// Copy assignment operator.
     BaseTexture& operator=(const BaseTexture& other);
 
-    virtual ~BaseTexture(){}
+    virtual ~BaseTexture()
+    {
+    }
     virtual void bind(uint32_t unit = 0) const = 0;
 
-    int getWidth() const { return m_width; }
-    int getHeight() const { return m_height; }
+    int getWidth() const
+    {
+        return m_width;
+    }
+    int getHeight() const
+    {
+        return m_height;
+    }
 
 protected:
     float m_width;
     float m_height;
 };
 
-}
+} // namespace spear::rendering
 
 #endif

--- a/engine/include/spear/rendering/opengl/error.hh
+++ b/engine/include/spear/rendering/opengl/error.hh
@@ -16,6 +16,6 @@ static void openglError(const char* label)
     }
 }
 
-}
+} // namespace spear::rendering::opengl
 
 #endif

--- a/engine/include/spear/rendering/opengl/renderer.hh
+++ b/engine/include/spear/rendering/opengl/renderer.hh
@@ -24,14 +24,14 @@ public:
 
     void setBackgroundColor(float r, float g, float b, float a);
     void init();
-private:
 
+private:
 private:
     SDL_Window* m_window;
     uint32_t m_shader_program;
     SDL_GLContext m_context;
 };
 
-}
+} // namespace spear::rendering::opengl
 
 #endif

--- a/engine/include/spear/rendering/opengl/shader.hh
+++ b/engine/include/spear/rendering/opengl/shader.hh
@@ -54,8 +54,14 @@ public:
     void use() override;
     void createShaderProgram() override;
 
-    int getVertexId() const { return m_vertexId; }
-    int getFragmentId() const { return m_fragmentId; }
+    int getVertexId() const
+    {
+        return m_vertexId;
+    }
+    int getFragmentId() const
+    {
+        return m_fragmentId;
+    }
 
 private:
     int getLocation(const std::string& name);
@@ -67,6 +73,6 @@ private:
     uint32_t m_fragmentId;
 };
 
-}
+} // namespace spear::rendering::opengl
 
 #endif

--- a/engine/include/spear/rendering/opengl/texture.hh
+++ b/engine/include/spear/rendering/opengl/texture.hh
@@ -39,10 +39,11 @@ public:
 
     // Free texture
     void free();
+
 private:
     uint32_t m_texture;
 };
 
-}
+} // namespace spear::rendering::opengl
 
 #endif

--- a/engine/include/spear/rendering/shader_type.hh
+++ b/engine/include/spear/rendering/shader_type.hh
@@ -1,8 +1,8 @@
 #ifndef SPEAR_RENDERING_SHADER_TYPE_HH
 #define SPEAR_RENDERING_SHADER_TYPE_HH
 
-#include <spear/rendering/base_shader.hh>
 #include <spear/rendering/api.hh>
+#include <spear/rendering/base_shader.hh>
 
 namespace spear::rendering
 {
@@ -22,6 +22,6 @@ struct ShaderFileData
 
 ShaderFileData getShaderFiles(ShaderType type, API api);
 
-}
+} // namespace spear::rendering
 
 #endif

--- a/engine/include/spear/shapes/ball.hh
+++ b/engine/include/spear/shapes/ball.hh
@@ -8,9 +8,8 @@ namespace spear
 
 class Ball : public Shape
 {
-
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/shapes/cube.hh
+++ b/engine/include/spear/shapes/cube.hh
@@ -1,9 +1,9 @@
 #ifndef SPEAR_SHAPE_HH
 #define SPEAR_SHAPE_HH
 
-#include <spear/shapes/shape.hh>
-#include <spear/rendering/opengl/texture.hh>
 #include <spear/camera.hh>
+#include <spear/rendering/opengl/texture.hh>
+#include <spear/shapes/shape.hh>
 
 #include <vector>
 
@@ -30,6 +30,6 @@ private:
     uint32_t m_uvDataSize;
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/shapes/quad.hh
+++ b/engine/include/spear/shapes/quad.hh
@@ -34,6 +34,6 @@ private:
     std::vector<float> m_vertices;
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/shapes/shape.hh
+++ b/engine/include/spear/shapes/shape.hh
@@ -1,8 +1,8 @@
 #ifndef SPEAR_SHAPE_SHAPE_HH
 #define SPEAR_SHAPE_SHAPE_HH
 
-#include <spear/mesh.hh>
 #include <spear/entity.hh>
+#include <spear/mesh.hh>
 
 namespace spear
 {
@@ -13,6 +13,6 @@ public:
     Shape(std::shared_ptr<rendering::BaseShader> shader);
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/spear_root.hh
+++ b/engine/include/spear/spear_root.hh
@@ -12,6 +12,6 @@ static const std::string spearRoot()
     return SPEAR_ROOT;
 }
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/sprite_3d.hh
+++ b/engine/include/spear/sprite_3d.hh
@@ -59,6 +59,7 @@ private:
     };
     */
 
+    // clang-format off
     const float m_vertices[20] = {
         // Positions        // Texture Coords
        -0.5f,  0.5f, 0.0f,  0.0f, 1.0f, // Top-left
@@ -67,11 +68,12 @@ private:
        -0.5f, -0.5f, 0.0f,  0.0f, 0.0f  // Bottom-left
     };
 
-    const uint32_t m_indices[6]
-    {
+    const uint32_t m_indices[6] = {
         0, 1, 2,
         2, 3, 0
     };
+    // clang-format on
+
     int32_t m_sampler;
 };
 

--- a/engine/include/spear/sprite_3d.hh
+++ b/engine/include/spear/sprite_3d.hh
@@ -2,13 +2,12 @@
 #define SPEAR_SPRITE_3D_HH
 
 #include <spear/rendering/base_texture.hh>
-#include <spear/rendering/opengl/shader.hh>
+#include <spear/rendering/opengl/error.hh>
 #include <spear/rendering/opengl/shader.hh>
 #include <spear/rendering/opengl/texture.hh>
-#include <spear/rendering/opengl/error.hh>
 
-#include <spear/transform.hh>
 #include <spear/mesh.hh>
+#include <spear/transform.hh>
 
 namespace spear
 {
@@ -77,6 +76,6 @@ private:
     int32_t m_sampler;
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/transform.hh
+++ b/engine/include/spear/transform.hh
@@ -13,12 +13,16 @@ public:
     virtual void translate(const glm::vec3& position);
     virtual void rotate(float speed, const glm::vec3& direction);
     virtual void scale(const glm::vec3& scale);
-    const glm::mat4& getModel() { return m_model; }
+    const glm::mat4& getModel()
+    {
+        return m_model;
+    }
     glm::vec3 getPosition() const;
+
 protected:
     glm::mat4 m_model;
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/include/spear/window.hh
+++ b/engine/include/spear/window.hh
@@ -3,11 +3,11 @@
 
 #include <spear/rendering/api.hh>
 
-#include <SDL3/SDL_video.h>
 #include <SDL3/SDL_events.h>
+#include <SDL3/SDL_video.h>
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace spear
 {
@@ -33,7 +33,10 @@ public:
 
     void update(rendering::API api);
     void resize();
-    Size getSize() const { return m_size; }
+    Size getSize() const
+    {
+        return m_size;
+    }
 
 private:
     void createWindow(const std::string& title, Size size, rendering::API api);
@@ -46,6 +49,6 @@ private:
     rendering::API m_api;
 };
 
-}
+} // namespace spear
 
 #endif

--- a/engine/src/camera.cc
+++ b/engine/src/camera.cc
@@ -1,5 +1,5 @@
-#include <spear/camera.hh>
 #include <glm/gtc/matrix_transform.hpp>
+#include <spear/camera.hh>
 
 namespace spear
 {
@@ -33,8 +33,10 @@ void Camera::rotate(float xoffset, float yoffset, bool constrain_pitch)
 
     if (constrain_pitch)
     {
-        if (m_pitch > 89.0f) m_pitch = 89.0f;
-        if (m_pitch < -89.0f) m_pitch = -89.0f;
+        if (m_pitch > 89.0f)
+            m_pitch = 89.0f;
+        if (m_pitch < -89.0f)
+            m_pitch = -89.0f;
     }
 
     updateCameraVectors();
@@ -43,8 +45,10 @@ void Camera::rotate(float xoffset, float yoffset, bool constrain_pitch)
 void Camera::zoom(float yoffset)
 {
     m_fov -= yoffset;
-    if (m_fov < 1.0f) m_fov = 1.0f;
-    if (m_fov > 45.0f) m_fov = 45.0f;
+    if (m_fov < 1.0f)
+        m_fov = 1.0f;
+    if (m_fov > 45.0f)
+        m_fov = 45.0f;
 }
 
 void Camera::updateCameraVectors()
@@ -60,4 +64,4 @@ void Camera::updateCameraVectors()
     m_up = glm::normalize(glm::cross(m_right, m_front));
 }
 
-}
+} // namespace spear

--- a/engine/src/event_handler.cc
+++ b/engine/src/event_handler.cc
@@ -12,7 +12,7 @@ void EventHandler::handleEvents()
         auto it = callbacks.find(event.type);
         if (it != callbacks.end())
         {
-            it->second(event);  // Call the registered callback
+            it->second(event); // Call the registered callback
         }
 
         // If no callback was set for SDL_QUIT, set running to false directly.
@@ -23,4 +23,4 @@ void EventHandler::handleEvents()
     }
 }
 
-}
+} // namespace spear

--- a/engine/src/material.cc
+++ b/engine/src/material.cc
@@ -1,6 +1,6 @@
-#include <spear/rendering/opengl/shader.hh>
-#include <spear/rendering/opengl/error.hh>
 #include <spear/material.hh>
+#include <spear/rendering/opengl/error.hh>
+#include <spear/rendering/opengl/shader.hh>
 
 #include <GL/glew.h>
 #include <SDL3/SDL.h>
@@ -65,7 +65,8 @@ void Material::use()
         std::cerr << "Shader program linking failed!" << std::endl;
         char infoLog[512];
         glGetProgramInfoLog(programId, 512, nullptr, infoLog);
-        std::cerr << "Linker error log:\n" << infoLog << std::endl;
+        std::cerr << "Linker error log:\n"
+                  << infoLog << std::endl;
         return;
     }
 
@@ -77,7 +78,8 @@ void Material::use()
         std::cerr << "Shader program validation failed!" << std::endl;
         char infoLog[512];
         glGetProgramInfoLog(programId, 512, nullptr, infoLog);
-        std::cerr << "Validation error log:\n" << infoLog << std::endl;
+        std::cerr << "Validation error log:\n"
+                  << infoLog << std::endl;
         return;
     }
 
@@ -121,5 +123,4 @@ void Material::use()
     rendering::opengl::openglError("glUniform1i");
 }
 
-}
-
+} // namespace spear

--- a/engine/src/mesh.cc
+++ b/engine/src/mesh.cc
@@ -8,4 +8,4 @@ Mesh::Mesh(std::shared_ptr<rendering::BaseShader> shader)
 {
 }
 
-}
+} // namespace spear

--- a/engine/src/rendering/api.cc
+++ b/engine/src/rendering/api.cc
@@ -7,13 +7,14 @@ bool isActive(API api)
 {
     switch (api)
     {
-        case spear::rendering::API::OpenGL: return true;
+        case spear::rendering::API::OpenGL:
+            return true;
         case spear::rendering::API::Vulkan:
         case spear::rendering::API::DirectX12:
-        case spear::rendering::API::Metal: break;
+        case spear::rendering::API::Metal:
+            break;
     }
     return false;
 }
 
-}
-
+} // namespace spear::rendering

--- a/engine/src/rendering/base_shader.cc
+++ b/engine/src/rendering/base_shader.cc
@@ -30,7 +30,8 @@ void BaseShader::checkCompileErrors(uint32_t shader, const std::string& type)
         if (!success)
         {
             glGetProgramInfoLog(shader, 1024, NULL, infoLog);
-            std::cerr << "ERROR::SHADER_PROGRAM::LINKING_FAILED\n" << infoLog << std::endl;
+            std::cerr << "ERROR::SHADER_PROGRAM::LINKING_FAILED\n"
+                      << infoLog << std::endl;
         }
     }
     else
@@ -39,15 +40,15 @@ void BaseShader::checkCompileErrors(uint32_t shader, const std::string& type)
         if (!success)
         {
             glGetShaderInfoLog(shader, 1024, NULL, infoLog);
-            std::cerr << "ERROR::SHADER::" << type << "::COMPILATION_FAILED\n" << infoLog << std::endl;
+            std::cerr << "ERROR::SHADER::" << type << "::COMPILATION_FAILED\n"
+                      << infoLog << std::endl;
         }
     }
 }
 
 BaseShader::~BaseShader()
 {
-	// TODO
+    // TODO
 }
 
-}
-
+} // namespace spear::rendering

--- a/engine/src/rendering/base_texture.cc
+++ b/engine/src/rendering/base_texture.cc
@@ -43,4 +43,4 @@ BaseTexture& BaseTexture::operator=(const BaseTexture& other)
     return *this;
 }
 
-}
+} // namespace spear::rendering

--- a/engine/src/rendering/opengl/renderer.cc
+++ b/engine/src/rendering/opengl/renderer.cc
@@ -40,4 +40,4 @@ void Renderer::setBackgroundColor(float r, float g, float b, float a)
     glClearColor(r, g, b, a);
 }
 
-}
+} // namespace spear::rendering::opengl

--- a/engine/src/rendering/opengl/shader.cc
+++ b/engine/src/rendering/opengl/shader.cc
@@ -6,8 +6,8 @@
 #include <glm/glm.hpp>
 
 #include <fstream>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 
 namespace spear::rendering::opengl
 {
@@ -18,60 +18,60 @@ Shader::Shader(ShaderType type)
     auto data = getShaderFiles(type, API::OpenGL);
 
     std::ifstream v_shader_file;
-	std::ifstream f_shader_file;
+    std::ifstream f_shader_file;
 
-	v_shader_file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-	f_shader_file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    v_shader_file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    f_shader_file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
-	try
-	{
-		// Open files.
-		v_shader_file.open(data.vertex_shader);
-		f_shader_file.open(data.fragment_shader);
-		std::stringstream vShaderStream, fShaderStream;
+    try
+    {
+        // Open files.
+        v_shader_file.open(data.vertex_shader);
+        f_shader_file.open(data.fragment_shader);
+        std::stringstream vShaderStream, fShaderStream;
 
-		// Read file's buffer contents into streams.
-		vShaderStream << v_shader_file.rdbuf();
-		fShaderStream << f_shader_file.rdbuf();
+        // Read file's buffer contents into streams.
+        vShaderStream << v_shader_file.rdbuf();
+        fShaderStream << f_shader_file.rdbuf();
 
-		// Close file handlers.
-		v_shader_file.close();
-		f_shader_file.close();
+        // Close file handlers.
+        v_shader_file.close();
+        f_shader_file.close();
 
-		// Convert into string.
-		m_vertexCode = vShaderStream.str();
-		m_fragmentCode = fShaderStream.str();
-	}
-	catch (const std::ifstream::failure& e)
-	{
-		printf("ERROR::SHADER::FILE_NOT_SUCCESFULLY_READ\n");
-	}
+        // Convert into string.
+        m_vertexCode = vShaderStream.str();
+        m_fragmentCode = fShaderStream.str();
+    }
+    catch (const std::ifstream::failure& e)
+    {
+        printf("ERROR::SHADER::FILE_NOT_SUCCESFULLY_READ\n");
+    }
 
     rendering::opengl::openglError("before compiling shaders");
 
-	// Compile shaders.
-	const char* vShaderCode = m_vertexCode.c_str();
-	const char* fShaderCode = m_fragmentCode.c_str();
+    // Compile shaders.
+    const char* vShaderCode = m_vertexCode.c_str();
+    const char* fShaderCode = m_fragmentCode.c_str();
 
-	// Vertex shader.
+    // Vertex shader.
     m_vertexId = glCreateShader(GL_VERTEX_SHADER);
-	glShaderSource(m_vertexId, 1, &vShaderCode, nullptr);
-	glCompileShader(m_vertexId);
-	checkCompileErrors(m_vertexId, "VERTEX");
+    glShaderSource(m_vertexId, 1, &vShaderCode, nullptr);
+    glCompileShader(m_vertexId);
+    checkCompileErrors(m_vertexId, "VERTEX");
 
-	// Fragment shader.
-	m_fragmentId = glCreateShader(GL_FRAGMENT_SHADER);
-	glShaderSource(m_fragmentId, 1, &fShaderCode, nullptr);
-	glCompileShader(m_fragmentId);
-	checkCompileErrors(m_fragmentId, "FRAGMENT");
+    // Fragment shader.
+    m_fragmentId = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(m_fragmentId, 1, &fShaderCode, nullptr);
+    glCompileShader(m_fragmentId);
+    checkCompileErrors(m_fragmentId, "FRAGMENT");
 
     rendering::opengl::openglError("after compiling shaders");
 
     createShaderProgram();
 
-	// Delete the shaders.
-	glDeleteShader(m_vertexId);
-	glDeleteShader(m_fragmentId);
+    // Delete the shaders.
+    glDeleteShader(m_vertexId);
+    glDeleteShader(m_fragmentId);
 
     rendering::opengl::openglError("opengl shader contructor");
 }
@@ -81,9 +81,9 @@ Shader::~Shader()
 }
 
 Shader::Shader(Shader&& other)
-	: BaseShader(std::move(other)),
-	  m_vertexCode(std::move(other.m_vertexCode)),
-	  m_fragmentCode(std::move(other.m_fragmentCode)),
+    : BaseShader(std::move(other)),
+      m_vertexCode(std::move(other.m_vertexCode)),
+      m_fragmentCode(std::move(other.m_fragmentCode)),
       m_vertexId(std::move(other.m_vertexId)),
       m_fragmentId(std::move(other.m_fragmentId))
 {
@@ -91,15 +91,15 @@ Shader::Shader(Shader&& other)
 
 Shader& Shader::operator=(Shader&& other)
 {
-	if (this != &other)
-	{
-		BaseShader::operator=(std::move(other));
-		m_vertexCode = std::move(other.m_vertexCode);
-		m_fragmentCode = std::move(other.m_fragmentCode);
+    if (this != &other)
+    {
+        BaseShader::operator=(std::move(other));
+        m_vertexCode = std::move(other.m_vertexCode);
+        m_fragmentCode = std::move(other.m_fragmentCode);
         m_vertexId = std::move(other.m_vertexId);
         m_fragmentId = std::move(other.m_fragmentId);
-	}
-	return *this;
+    }
+    return *this;
 }
 
 int Shader::getLocation(const std::string& name)
@@ -199,7 +199,6 @@ void Shader::setSampler2D(const std::string& name, int textureUnit)
         return;
     }
 
-
     int location = getLocation(name);
     if (location != -1)
     {
@@ -241,4 +240,4 @@ void Shader::createShaderProgram()
     BaseShader::setId(program);
 }
 
-}
+} // namespace spear::rendering::opengl

--- a/engine/src/rendering/opengl/texture.cc
+++ b/engine/src/rendering/opengl/texture.cc
@@ -2,8 +2,8 @@
 #include <spear/rendering/opengl/texture.hh>
 #include <spear/spear_root.hh>
 
-#include <SDL3_image/SDL_image.h>
 #include <GL/glew.h>
+#include <SDL3_image/SDL_image.h>
 
 #include <iostream>
 
@@ -73,7 +73,7 @@ bool Texture::loadFile(const std::string& path, bool asset_path)
     SDL_Surface* surface = IMG_Load(used_path.c_str());
     if (!surface)
     {
-        std::cerr << "Failed to load image: " << path 
+        std::cerr << "Failed to load image: " << path
                   << " | SDL_Error: " << SDL_GetError() << std::endl;
         return false;
     }
@@ -93,17 +93,16 @@ bool Texture::loadFile(const std::string& path, bool asset_path)
 
     // Upload texture data to GPU.
     glTexImage2D(
-        GL_TEXTURE_2D,
-        0,
-        //format,
-        GL_RGBA,
-        surface->w,
-        surface->h,
-        0,
-        format,
-        GL_UNSIGNED_BYTE,
-        surface->pixels
-    );
+            GL_TEXTURE_2D,
+            0,
+            // format,
+            GL_RGBA,
+            surface->w,
+            surface->h,
+            0,
+            format,
+            GL_UNSIGNED_BYTE,
+            surface->pixels);
     glGenerateMipmap(GL_TEXTURE_2D);
 
     // Store dimensions.
@@ -146,4 +145,4 @@ void Texture::free()
     }
 }
 
-}
+} // namespace spear::rendering::opengl

--- a/engine/src/rendering/shader_type.cc
+++ b/engine/src/rendering/shader_type.cc
@@ -18,29 +18,37 @@ ShaderFileData getShaderFiles(ShaderType type, API api)
                 {
                     std::string vertexPath = spearRoot() + "/shaders/basic_vertex.glsl";
                     std::string fragPath = spearRoot() + "/shaders/basic_fragment.glsl";
-                    std::cout << "Selecting opengl shaders:\n" << vertexPath << "\n" << fragPath << "\n "<< std::endl;
-                    return { vertexPath, fragPath };
+                    std::cout << "Selecting opengl shaders:\n"
+                              << vertexPath << "\n"
+                              << fragPath << "\n " << std::endl;
+                    return {vertexPath, fragPath};
                 }
                 case ShaderType::lighting:
                 {
                     std::string vertexPath = spearRoot() + "/shaders/lighting_vertex.glsl";
                     std::string fragPath = spearRoot() + "/shaders/lighting_fragment.glsl";
-                    std::cout << "Selecting opengl shaders:\n" << vertexPath << "\n" << fragPath << "\n "<< std::endl;
-                    return { vertexPath, fragPath };
+                    std::cout << "Selecting opengl shaders:\n"
+                              << vertexPath << "\n"
+                              << fragPath << "\n " << std::endl;
+                    return {vertexPath, fragPath};
                 }
                 case ShaderType::sprite3D:
                 {
                     std::string vertexPath = spearRoot() + "/shaders/sprite3d_vertex.glsl";
                     std::string fragPath = spearRoot() + "/shaders/sprite3d_fragment.glsl";
-                    std::cout << "Selecting opengl shaders:\n" << vertexPath << "\n" << fragPath << "\n "<< std::endl;
-                    return { vertexPath, fragPath };
+                    std::cout << "Selecting opengl shaders:\n"
+                              << vertexPath << "\n"
+                              << fragPath << "\n " << std::endl;
+                    return {vertexPath, fragPath};
                 }
                 case ShaderType::quad:
                 {
                     std::string vertexPath = spearRoot() + "/shaders/quad_vertex.glsl";
                     std::string fragPath = spearRoot() + "/shaders/quad_fragment.glsl";
-                    std::cout << "Selecting opengl shaders:\n" << vertexPath << "\n" << fragPath << "\n "<< std::endl;
-                    return { vertexPath, fragPath };
+                    std::cout << "Selecting opengl shaders:\n"
+                              << vertexPath << "\n"
+                              << fragPath << "\n " << std::endl;
+                    return {vertexPath, fragPath};
                 }
             }
             break;
@@ -53,4 +61,4 @@ ShaderFileData getShaderFiles(ShaderType type, API api)
     return {"", ""};
 }
 
-}
+} // namespace spear::rendering

--- a/engine/src/shapes/cube.cc
+++ b/engine/src/shapes/cube.cc
@@ -190,6 +190,7 @@ void Cube::render(Camera& camera)
 
 std::vector<float> Cube::createVertexBufferData(const glm::vec3& v)
 {
+    // clang-format off
     return std::vector<float>
     {
         -v.x, -v.y, -v.z,
@@ -234,10 +235,12 @@ std::vector<float> Cube::createVertexBufferData(const glm::vec3& v)
         -v.x,  v.y,  v.z,
         -v.x,  v.y, -v.z
     };
+    // clang-format on
 }
 
 std::vector<float> Cube::createUvData()
 {
+    // clang-format off
     return std::vector<float>
     {
         0.0f, 0.0f,
@@ -282,6 +285,7 @@ std::vector<float> Cube::createUvData()
         0.0f, 0.0f,
         0.0f, 1.0f
     };
+    // clang-format on
 }
 
 }

--- a/engine/src/shapes/cube.cc
+++ b/engine/src/shapes/cube.cc
@@ -1,6 +1,6 @@
 #include "spear/transform.hh"
-#include <spear/shapes/cube.hh>
 #include <spear/rendering/opengl/error.hh>
+#include <spear/shapes/cube.hh>
 
 #include <SDL3/SDL.h>
 
@@ -24,7 +24,7 @@ void Cube::create(std::vector<float>&& vertex_buffer_data, std::vector<float>&& 
     assert(m_vertexDataSize == vertex_buffer_data.size());
 
     m_uvDataSize = uv_data.size();
-    assert (uv_data.size() == 72);
+    assert(uv_data.size() == 72);
     assert(m_uvDataSize == uv_data.size());
 
     glGenVertexArrays(1, &m_vao);
@@ -288,4 +288,4 @@ std::vector<float> Cube::createUvData()
     // clang-format on
 }
 
-}
+} // namespace spear

--- a/engine/src/shapes/quad.cc
+++ b/engine/src/shapes/quad.cc
@@ -34,6 +34,7 @@ void Quad::translate(const glm::vec3& position)
 
 void Quad::initialize(const glm::vec3& position)
 {
+    // clang-format off
     m_vertices =
     {
         position.x-0.5f, position.y-0.5f, position.z-0.5f,  m_color.x, m_color.y, m_color.z,
@@ -55,6 +56,7 @@ void Quad::initialize(const glm::vec3& position)
         0, 3, 7, 7, 4, 0,   // Left face
         1, 2, 6, 6, 5, 1    // Right face
     };
+    // clang-format on
 
     // Create VAO, VBO, and EBO
     glGenVertexArrays(1, &m_vao);

--- a/engine/src/shapes/quad.cc
+++ b/engine/src/shapes/quad.cc
@@ -1,6 +1,6 @@
-#include <spear/shapes/quad.hh>
 #include <GL/glew.h>
 #include <glm/gtc/type_ptr.hpp>
+#include <spear/shapes/quad.hh>
 
 #include <vector>
 
@@ -95,4 +95,4 @@ void Quad::render(Camera& camera)
     glBindVertexArray(0);
 }
 
-}
+} // namespace spear

--- a/engine/src/shapes/shape.cc
+++ b/engine/src/shapes/shape.cc
@@ -8,4 +8,4 @@ Shape::Shape(std::shared_ptr<rendering::BaseShader> shader)
 {
 }
 
-}
+} // namespace spear

--- a/engine/src/sprite3d.cc
+++ b/engine/src/sprite3d.cc
@@ -12,9 +12,12 @@ Sprite3D::Sprite3D(glm::vec3 position)
 
 Sprite3D::~Sprite3D()
 {
-    if (m_vao) glDeleteVertexArrays(1, &m_vao);
-    if (m_vbo) glDeleteBuffers(1, &m_vbo);
-    if (m_ebo) glDeleteBuffers(1, &m_ebo);
+    if (m_vao)
+        glDeleteVertexArrays(1, &m_vao);
+    if (m_vbo)
+        glDeleteBuffers(1, &m_vbo);
+    if (m_ebo)
+        glDeleteBuffers(1, &m_ebo);
 }
 
 void Sprite3D::render(Camera& camera)
@@ -65,4 +68,4 @@ void Sprite3D::loadImage(const std::string& path)
     m_texture.bind();
 }
 
-}
+} // namespace spear

--- a/engine/src/transform.cc
+++ b/engine/src/transform.cc
@@ -3,7 +3,8 @@
 namespace spear
 {
 
-Transform::Transform() : m_model(glm::mat4(1))
+Transform::Transform()
+    : m_model(glm::mat4(1))
 {
 }
 
@@ -27,4 +28,4 @@ glm::vec3 Transform::getPosition() const
     return glm::vec3(m_model[3][0], m_model[3][1], m_model[3][2]);
 }
 
-}
+} // namespace spear

--- a/engine/src/window.cc
+++ b/engine/src/window.cc
@@ -1,17 +1,17 @@
-#include <SDL3/SDL_video.h>
 #include <SDL3/SDL.h>
+#include <SDL3/SDL_video.h>
 #include <spear/window.hh>
 
-#include <SDL3/SDL.h>
 #include <GL/glew.h>
+#include <SDL3/SDL.h>
 
 #include <iostream>
 
 namespace spear
 {
 
-Window::Window(const std::string& window_name, Size size, rendering::API api) :
-    m_window(nullptr), m_size(size), m_api(api)
+Window::Window(const std::string& window_name, Size size, rendering::API api)
+    : m_window(nullptr), m_size(size), m_api(api)
 {
     if (!SDL_Init(SDL_INIT_VIDEO))
     {
@@ -60,7 +60,7 @@ void Window::createWindow(const std::string& title, Size size, rendering::API ap
             }
             break;
         case rendering::API::Vulkan:
-            //flags = SDL_WINDOW_VULKAN;
+            // flags = SDL_WINDOW_VULKAN;
         case rendering::API::Metal:
         case rendering::API::DirectX12:
             perror("Unimplemented");
@@ -82,7 +82,7 @@ void Window::initializeContext(rendering::API api)
                 return;
             }
             // vsync
-            //SDL_GL_SetSwapInterval(1);
+            // SDL_GL_SetSwapInterval(1);
             std::cout << "OpenGL context initialized.\n";
             break;
         case rendering::API::Vulkan:
@@ -111,5 +111,4 @@ void Window::resize()
     SDL_GetWindowSize(m_window, &m_size.x, &m_size.y);
 }
 
-}
-
+} // namespace spear

--- a/runtime/main.cc
+++ b/runtime/main.cc
@@ -1,12 +1,12 @@
-#include <spear/window.hh>
+#include <spear/camera.hh>
 #include <spear/event_handler.hh>
 #include <spear/shapes/cube.hh>
-#include <spear/camera.hh>
-#include <spear/sprite_3d.hh>
 #include <spear/shapes/quad.hh>
+#include <spear/sprite_3d.hh>
+#include <spear/window.hh>
 
-#include <spear/rendering/opengl/shader.hh>
 #include <spear/rendering/opengl/renderer.hh>
+#include <spear/rendering/opengl/shader.hh>
 #include <spear/rendering/opengl/texture.hh>
 
 #include <iostream>
@@ -14,7 +14,7 @@
 int main()
 {
     const std::string window_name = "Spear application";
-    const spear::Window::Size window_size = { 820, 640 };
+    const spear::Window::Size window_size = {820, 640};
     const spear::rendering::API gl_api = spear::rendering::API::OpenGL;
 
     spear::Window window(window_name, window_size, gl_api);
@@ -29,19 +29,16 @@ int main()
     spear::EventHandler eventHandler;
 
     eventHandler.registerCallback(SDL_EVENT_MOUSE_BUTTON_DOWN, [](const SDL_Event& event)
-    {
-        std::cout << "Mouse button pressed at (" << event.button.x << ", " << event.button.y << ")" << std::endl;
-    });
+                                  { std::cout << "Mouse button pressed at (" << event.button.x << ", " << event.button.y << ")" << std::endl; });
 
     eventHandler.registerCallback(SDL_EVENT_QUIT, [](const SDL_Event&)
-    {
+                                  {
         std::cout << "Quit event received. Exiting..." << std::endl;
-        exit(0);
-    });
+        exit(0); });
 
     // Movement.
     eventHandler.registerCallback(SDL_EVENT_KEY_DOWN, [&camera](const SDL_Event& event)
-    {
+                                  {
         switch (event.key.key)
         {
             case SDLK_W:
@@ -68,34 +65,34 @@ int main()
                 std::cout << "Move D pressed" << std::endl;
                 break;
             }
-        }
-    });
+        } });
 
     // Update window size.
-    eventHandler.registerCallback(SDL_EVENT_WINDOW_RESIZED, [&window](const SDL_Event&){ window.resize(); });
+    eventHandler.registerCallback(SDL_EVENT_WINDOW_RESIZED, [&window](const SDL_Event&)
+                                  { window.resize(); });
 
-    //auto quad_shader = spear::rendering::opengl::Shader::create(spear::rendering::ShaderType::quad);
+    // auto quad_shader = spear::rendering::opengl::Shader::create(spear::rendering::ShaderType::quad);
     spear::Quad quad(glm::vec3(0.5f, 0.f, 0.2f));
     quad.initialize(glm::vec3(0.0f, 0.0f, 0.0f));
 
-    //auto sprite_shader = spear::rendering::opengl::Shader::create(spear::rendering::ShaderType::sprite3D);
-    //auto shader_id = sprite_shader->getId();
-    //std::cout << "Shader id: " << shader_id << std::endl;
+    // auto sprite_shader = spear::rendering::opengl::Shader::create(spear::rendering::ShaderType::sprite3D);
+    // auto shader_id = sprite_shader->getId();
+    // std::cout << "Shader id: " << shader_id << std::endl;
 
-    //auto texture = spear::rendering::opengl::Texture(shader_id);
-    //texture.loadFile("niilo.jpg");
-    //auto shared_texture = std::make_shared<spear::rendering::opengl::Texture>(std::move(texture));
+    // auto texture = spear::rendering::opengl::Texture(shader_id);
+    // texture.loadFile("niilo.jpg");
+    // auto shared_texture = std::make_shared<spear::rendering::opengl::Texture>(std::move(texture));
 
-    //spear::Sprite3D sprite(sprite_shader, shared_texture, glm::vec3(0.f, 0.f, 0.f));
-    //spear::Sprite3D sprite2(sprite_shader, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+    // spear::Sprite3D sprite(sprite_shader, shared_texture, glm::vec3(0.f, 0.f, 0.f));
+    // spear::Sprite3D sprite2(sprite_shader, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
 
     while (true)
     {
         quad.translate(glm::vec3(1.0f, 0.0f, 0.0f));
-        //sprite.render(camera);
-        //sprite2.render(camera);
+        // sprite.render(camera);
+        // sprite2.render(camera);
         renderer.render();
-        //quad.render(camera);
+        // quad.render(camera);
         eventHandler.handleEvents();
         window.update(gl_api);
     }


### PR DESCRIPTION
- Added `.clang-format` and formatted all files
- Added GitHub workflow for code format checking

Tested in [jervw/spear](https://github.com/jervw/spear/actions)

Feel free to suggest any adjustments to the clang-format style if you'd prefer different options